### PR TITLE
Fix post-jdbc.core-migration problems (column names, upsert, position…

### DIFF
--- a/bin/setup-db.sh
+++ b/bin/setup-db.sh
@@ -62,6 +62,9 @@ create table game_rating (
   created_at timestamp not null default current_timestamp,
   updated_at timestamp not null default current_timestamp);
 
+alter table game_rating add constraint cost_unique__game_rating_game_id_member_id
+unique (game_id, member_id);
+
 create trigger game_rating_updated_at before update
 on game_rating for each row execute procedure 
 mantain_updated_at();

--- a/resources/cgg-schema.edn
+++ b/resources/cgg-schema.edn
@@ -32,7 +32,7 @@
   {:description "A member of Clojure Game Geek.  Members can rate games."
    :fields
    {:member_id {:type (non-null Int)}
-    :member_name {:type (non-null String)
+    :name {:type (non-null String)
                   :description "Unique name of member."}
     :ratings {:type (list :GameRating)
               :description "List of games and ratings provided by this member."

--- a/src/clojure_game_geek/schema.clj
+++ b/src/clojure_game_geek/schema.clj
@@ -48,17 +48,17 @@
 (defn board-game-designers
   [db]
   (fn [_ _ board-game]
-    (db/list-designers-for-game db (:id board-game))))
+    (db/list-designers-for-game db (:game_id board-game))))
 
 (defn designer-games
   [db]
   (fn [_ _ designer]
-    (db/list-games-for-designer db (:id designer))))
+    (db/list-games-for-designer db (:designer_id designer))))
 
 (defn rating-summary
   [db]
   (fn [_ _ board-game]
-    (let [ratings (map :rating (db/list-ratings-for-game db (:id board-game)))
+    (let [ratings (map :rating (db/list-ratings-for-game db (:game_id board-game)))
           n (count ratings)]
       {:count n
        :average (if (zero? n)
@@ -69,7 +69,7 @@
 (defn member-ratings
   [db]
   (fn [_ _ member]
-    (db/list-ratings-for-member db (:id member))))
+    (db/list-ratings-for-member db (:member_id member))))
 
 (defn game-rating->game
   [db]


### PR DESCRIPTION
Hi, after reading the tutorial up to `Testing, Phase 1`part (so far well-written IMO!), I gave this `clojure-game-geek` repository a try in order to be able to play with GraphiQL a bit.

Unfortunately, the codebase didn't really work for me and I had to fix a few issues in order to be able to successfully use GraphiQL with all the subgraph fetches & mutations working. I'm not sure if the changes are correct and complete, but they worked for me, so I'm sharing them.

Here's what I had to fix:

1) `db.clj` : some SQL queries used parameters such as $1. According to git log, is seems that `postgres.async` was used in the past and it supports such form of positional query parameters. But in `java.jdbc`, one has to use simpler `?` form (and pass the same value multiple times if present multiple times in statement, such as in case of `rating` in `upsert-game-rating`).

2) `cgg-schema.edn`: had to change `:member_name` to `:name` in `:Member` object, as the column in `member` table is called just `name`, not `member_name`

3) `db.clj` : had to add `execute!` function and use it inside `upsert-game-rating` instead of `query`. Otherwise (when `query` function was used) the update part of the statement would actually be executed successfully, but since it returned no result, the `query` function itself would then immediately fail.

4) `schema.clj` : had to modify `(:id board-game)` to `(:game_id board-game)` etc as columns in db are called `game_id`, `designer_id` etc.

5) `setup-db.sh` : had to add unique constraint on combination of columns `game_id`+`member_id` of `game_rating` table. Otherwise the `on conflict (game_id, member_id) do update set rating = ?` part of `upsert-game-rating` function would crash due to missing uniqe constraint.

After mentioned changes, I'm able to perform following GraphQL mutation...

Request:
```graphql
mutation {
  rate_game(game_id:1234, member_id: 37, rating: 5) {
    description
    max_players
    min_players
    play_time
    summary
  }
}
```
Response:
```json
{
  "data": {
    "rate_game": {
      "description": null,
      "max_players": 2,
      "min_players": 2,
      "play_time": null,
      "summary": "Two player abstract with forced moves and shrinking board"
    }
  }
}
```

... and also following query:

Request:
```graphql
{
  game_by_id(id: 1234) {
    game_id
    name
    min_players
    max_players
    play_time
    summary
    designers {
      name
      url
      games {
        name
      }
    }
    rating_summary {
      count
      average
    }
  }
  member_by_id(id: 37) {
    member_id
    name
    ratings {
      game {
        game_id
        name
      }
      rating
    }
  }
}

Response:
```

```json
{
  "data": {
    "game_by_id": {
      "game_id": 1234,
      "name": "Zertz",
      "min_players": 2,
      "max_players": 2,
      "play_time": null,
      "summary": "Two player abstract with forced moves and shrinking board",
      "designers": [
        {
          "name": "Kris Burm",
          "url": null,
          "games": [
            {
              "name": "Zertz"
            }
          ]
        }
      ],
      "rating_summary": {
        "count": 2,
        "average": 5
      }
    },
    "member_by_id": {
      "member_id": 37,
      "name": "curiousattemptbunny",
      "ratings": [
        {
          "game": {
            "game_id": 1234,
            "name": "Zertz"
          },
          "rating": 5
        }
      ]
    }
  }
}
```